### PR TITLE
TASK-10: Move commonly used values to separate file and reposition locally used values to be easier found and changed

### DIFF
--- a/PreciousMetalsManager/Models/CollectableTypeToLabelConverter.cs
+++ b/PreciousMetalsManager/Models/CollectableTypeToLabelConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+using PreciousMetalsManager.Domain;
 using PreciousMetalsManager.Models;
 
 namespace PreciousMetalsManager.Models
@@ -35,15 +36,7 @@ namespace PreciousMetalsManager.Models
 
         private static string GetLabelWithoutColon(CollectableType collectableType)
         {
-            var key = collectableType switch
-            {
-                CollectableType.Bullion => "CollectableType_Bullion",
-                CollectableType.SemiNumismatic => "CollectableType_SemiNumismatic",
-                CollectableType.Numismatic => "CollectableType_Numismatic",
-                _ => null
-            };
-
-            if (key is null)
+            if (!DomainReferenceData.TryGetCollectableLabelResourceKey(collectableType, out var key))
                 return collectableType.ToString();
 
             var label = Application.Current.TryFindResource(key) as string;

--- a/PreciousMetalsManager/Models/MetalHolding.cs
+++ b/PreciousMetalsManager/Models/MetalHolding.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using PreciousMetalsManager.Domain;
 
 namespace PreciousMetalsManager.Models
 {
@@ -106,7 +107,7 @@ namespace PreciousMetalsManager.Models
                 if (PurchaseDate == default)
                     return string.Empty;
 
-                var taxFreeDate = PurchaseDate.Date.AddYears(1);
+                var taxFreeDate = PurchaseDate.Date.AddYears(DomainReferenceData.Tax.TaxFreeHoldingPeriodYears);
                 if (DateTime.Today >= taxFreeDate)
                     return L("TaxFreeStatus_Yes");
                 else
@@ -118,7 +119,7 @@ namespace PreciousMetalsManager.Models
         /// True if the holding period is at least 1 year.
         /// </summary>
         public bool IsTaxFree =>
-            PurchaseDate != default && DateTime.Today >= PurchaseDate.Date.AddYears(1);
+            PurchaseDate != default && DateTime.Today >= PurchaseDate.Date.AddYears(DomainReferenceData.Tax.TaxFreeHoldingPeriodYears);
 
         /// <summary>
         /// Notifies the UI that TaxFreeStatus and IsTaxFree have changed.
@@ -137,8 +138,9 @@ namespace PreciousMetalsManager.Models
             get
             {
                 if (PurchaseDate == default)
-                    return int.MaxValue; // Unset dates last
-                var taxFreeDate = PurchaseDate.Date.AddYears(1);
+                    return int.MaxValue;
+
+                var taxFreeDate = PurchaseDate.Date.AddYears(DomainReferenceData.Tax.TaxFreeHoldingPeriodYears);
                 return DateTime.Today >= taxFreeDate ? 0 : (taxFreeDate - DateTime.Today).Days;
             }
         }

--- a/PreciousMetalsManager/Models/MetalTypeToLabelConverter.cs
+++ b/PreciousMetalsManager/Models/MetalTypeToLabelConverter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
+using PreciousMetalsManager.Domain;
 using PreciousMetalsManager.Models;
 
 namespace PreciousMetalsManager.Models
@@ -37,17 +38,7 @@ namespace PreciousMetalsManager.Models
 
         private static string GetLabelWithoutColon(MetalType metalType)
         {
-            var key = metalType switch
-            {
-                MetalType.Gold => "Lbl_Gold",
-                MetalType.Silver => "Lbl_Silver",
-                MetalType.Platinum => "Lbl_Platinum",
-                MetalType.Palladium => "Lbl_Palladium",
-                MetalType.Bronce => "Lbl_Bronce",
-                _ => null
-            };
-
-            if (key is null)
+            if (!DomainReferenceData.TryGetMetalLabelResourceKey(metalType, out var key))
                 return metalType.ToString();
 
             var label = Application.Current.TryFindResource(key) as string;

--- a/PreciousMetalsManager/PreciousMetalsManager/Domain/DomainReferenceData.cs
+++ b/PreciousMetalsManager/PreciousMetalsManager/Domain/DomainReferenceData.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using PreciousMetalsManager.Models;
+
+namespace PreciousMetalsManager.Domain
+{
+    public static class DomainReferenceData
+    {
+        public sealed record CurrencyDefinition(string Code, string Symbol);
+
+        public static class Currency
+        {
+            public const string DefaultCode = "EUR";
+            public const string DefaultSymbol = "€";
+            public const string PricePerGramUnit = "€/g";
+            public const string CurrencyUnit = "(€)";
+            public const string SimplifiedCurrencyUnit = "€";
+            public const string WeightUnit = "(g)";
+            public const string PurityUnit = "(‰)";
+
+            public static IReadOnlyList<CurrencyDefinition> SupportedCurrencies { get; } =
+            [
+                new(DefaultCode, DefaultSymbol)
+            ];
+        }
+
+        public static class PreciousMetals
+        {
+            // A Purity of 999.9 is considered as highest purity (100%)
+            public const decimal MaximumFinenessPermille = 999.9m;
+
+            public const decimal MinimumFinenessPermille = 0.1m;
+            
+            // 1 troy ounce = 31.1g (may be adjusted to the exact value in the future)
+            public const decimal RoundedTroyOunceInGrams = 31.1m;
+
+            // Common purities for metals for easy selection in the UI, may be adjusted in the future
+            public static IReadOnlyList<decimal> CommonFinenessValues { get; } =
+            [
+                999.9m,
+                925.0m,
+                900.0m,
+                835.0m,
+                800.0m,
+                750.0m,
+                625.0m
+            ];
+
+            public static IReadOnlyDictionary<MetalType, string> LabelResourceKeys { get; } =
+                new Dictionary<MetalType, string>
+                {
+                    [MetalType.Gold] = "Lbl_Gold",
+                    [MetalType.Silver] = "Lbl_Silver",
+                    [MetalType.Platinum] = "Lbl_Platinum",
+                    [MetalType.Palladium] = "Lbl_Palladium",
+                    [MetalType.Bronce] = "Lbl_Bronce"
+                };
+        }
+
+        public static class Collectables
+        {
+            public static IReadOnlyDictionary<CollectableType, string> LabelResourceKeys { get; } =
+                new Dictionary<CollectableType, string>
+                {
+                    [CollectableType.Bullion] = "CollectableType_Bullion",
+                    [CollectableType.SemiNumismatic] = "CollectableType_SemiNumismatic",
+                    [CollectableType.Numismatic] = "CollectableType_Numismatic"
+                };
+        }
+
+        public static class Tax
+        {
+            public const int TaxFreeHoldingPeriodYears = 1;
+        }
+
+        public static bool TryGetMetalLabelResourceKey(MetalType metalType, out string resourceKey)
+            => PreciousMetals.LabelResourceKeys.TryGetValue(metalType, out resourceKey!);
+
+        public static bool TryGetCollectableLabelResourceKey(CollectableType collectableType, out string resourceKey)
+            => Collectables.LabelResourceKeys.TryGetValue(collectableType, out resourceKey!);
+    }
+}

--- a/PreciousMetalsManager/Resources/Localization/Localization.de.xaml
+++ b/PreciousMetalsManager/Resources/Localization/Localization.de.xaml
@@ -108,4 +108,5 @@
     <sys:String x:Key="ImportDialog_Error">Fehler beim Import</sys:String>
     <sys:String x:Key="ImportDialog_OverwritePrompt">Bestehende Bestände vor dem Import löschen?</sys:String>
     <sys:String x:Key="ImportDialog_OverwritePrompt_Title">Import-Optionen</sys:String>
+    <sys:String x:Key="ImportDialog_Filter">CSV-Datei (*.csv)|*.csv</sys:String>
 </ResourceDictionary>

--- a/PreciousMetalsManager/Resources/Localization/Localization.en.xaml
+++ b/PreciousMetalsManager/Resources/Localization/Localization.en.xaml
@@ -109,4 +109,5 @@
     <sys:String x:Key="ImportDialog_Error">Error during import</sys:String>
     <sys:String x:Key="ImportDialog_OverwritePrompt">Delete existing holdings before import?</sys:String>
     <sys:String x:Key="ImportDialog_OverwritePrompt_Title">Import Options</sys:String>
+    <sys:String x:Key="ImportDialog_Filter">CSV file (*.csv)|*.csv</sys:String>
 </ResourceDictionary>

--- a/PreciousMetalsManager/Services/CsvExportService.cs
+++ b/PreciousMetalsManager/Services/CsvExportService.cs
@@ -1,19 +1,25 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows;
+using PreciousMetalsManager.Domain;
 using PreciousMetalsManager.Models;
 
 namespace PreciousMetalsManager.Services
 {
     public static class CsvExportService
     {
+        private const string SimpleExportDateFormat = "yyyy-MM-dd";
+        private const string DetailedExportDateFormat = "dd.MM.yyyy";
+        private const string PriceNumberFormat = "F2";
+
         public static void ExportHoldings(IEnumerable<MetalHolding> holdings, string filePath)
         {
             var sb = new StringBuilder();
             foreach (var h in holdings)
             {
-                sb.AppendLine($"{(int)h.MetalType};{h.Form};{(int)h.CollectableType};{h.Purity};{h.Weight};{h.Quantity};{h.PurchasePrice};{h.PurchaseDate:yyyy-MM-dd}");
+                sb.AppendLine($"{(int)h.MetalType};{h.Form};{(int)h.CollectableType};{h.Purity};{h.Weight};{h.Quantity};{h.PurchasePrice};{h.PurchaseDate.ToString(SimpleExportDateFormat, CultureInfo.InvariantCulture)}");
             }
             File.WriteAllText(filePath, sb.ToString(), Encoding.UTF8);
         }
@@ -24,23 +30,15 @@ namespace PreciousMetalsManager.Services
 
             string L(string key) => Application.Current?.TryFindResource(key) as string ?? key;
 
-            static string GetMetalTypeKey(MetalType metalType) => metalType switch
-            {
-                MetalType.Gold => "Lbl_Gold",
-                MetalType.Silver => "Lbl_Silver",
-                MetalType.Platinum => "Lbl_Platinum",
-                MetalType.Palladium => "Lbl_Palladium",
-                MetalType.Bronce => "Lbl_Bronce",
-                _ => metalType.ToString()
-            };
+            static string GetMetalTypeKey(MetalType metalType)
+                => DomainReferenceData.TryGetMetalLabelResourceKey(metalType, out var key)
+                    ? key
+                    : metalType.ToString();
 
-            static string GetCollectableTypeKey(CollectableType collectableType) => collectableType switch
-            {
-                CollectableType.Bullion => "CollectableType_Bullion",
-                CollectableType.SemiNumismatic => "CollectableType_SemiNumismatic",
-                CollectableType.Numismatic => "CollectableType_Numismatic",
-                _ => collectableType.ToString()
-            };
+            static string GetCollectableTypeKey(CollectableType collectableType)
+                => DomainReferenceData.TryGetCollectableLabelResourceKey(collectableType, out var key)
+                    ? key
+                    : collectableType.ToString();
 
             static string TrimTrailingColon(string s) => string.IsNullOrWhiteSpace(s) ? s : s.TrimEnd().TrimEnd(':');
 
@@ -67,8 +65,8 @@ namespace PreciousMetalsManager.Services
                     $"{h.Purity}; " +
                     $"{h.Weight}; " +
                     $"{h.Quantity}; " +
-                    $"{h.PurchasePrice:F2}; " +
-                    $"{h.PurchaseDate:dd.MM.yyyy}; "
+                    $"{h.PurchasePrice.ToString(PriceNumberFormat, CultureInfo.InvariantCulture)}; " +
+                    $"{h.PurchaseDate.ToString(DetailedExportDateFormat, CultureInfo.InvariantCulture)}; "
                 );
             }
 

--- a/PreciousMetalsManager/ViewModel/ViewModel.cs
+++ b/PreciousMetalsManager/ViewModel/ViewModel.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Threading;
 using Microsoft.Win32;
+using System.Globalization;
+using PreciousMetalsManager.Domain;
 
 namespace PreciousMetalsManager.ViewModels
 {
@@ -101,6 +103,22 @@ namespace PreciousMetalsManager.ViewModels
         private readonly DispatcherTimer _autoRefreshTimer;
         private bool _isReloadingHoldings;
 
+        // Auto-refresh every 15 minutes
+        private const int AutoRefreshIntervalMinutes = 15;
+        private const int PriceDecimalPlaces = 2;
+        private const string PriceNumberFormat = "F2";
+        private const string PurityNumberFormat = "F1";
+        private const string ExportFileDateFormat = "dd-MM-yyyy";
+        private const string ImportExportCsvDateFormat = "yyyy-MM-dd";
+
+        private static decimal ConvertOuncePriceToGramPrice(decimal ouncePrice)
+            => Math.Round(
+                ouncePrice / DomainReferenceData.PreciousMetals.RoundedTroyOunceInGrams,
+                PriceDecimalPlaces);
+
+        private static string FormatPrice(decimal value)
+            => value.ToString(PriceNumberFormat, CultureInfo.InvariantCulture);
+
         public ViewModel(LocalStorageService? storage = null)
         {
             _storage = storage ?? new LocalStorageService();
@@ -115,10 +133,9 @@ namespace PreciousMetalsManager.ViewModels
 
             RefreshPricesCommand = new RelayCommand(async _ => await UpdateMarketPricesAsync());
 
-            // Auto-refresh every 15 minutes
             _autoRefreshTimer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromMinutes(15)
+                Interval = TimeSpan.FromMinutes(AutoRefreshIntervalMinutes)
             };
             _autoRefreshTimer.Tick += async (s, e) => await UpdateMarketPricesAsync();
             _autoRefreshTimer.Start();
@@ -178,8 +195,10 @@ namespace PreciousMetalsManager.ViewModels
             foreach (var holding in Holdings)
             {
                 var price = GetMarketPrice(holding.MetalType);
-                // A Purity of 999.9 is considered as highest purity (100%)
-                holding.CurrentValue = holding.Weight * (holding.Purity / 999.9m) * price;
+                holding.CurrentValue =
+                    holding.Weight *
+                    (holding.Purity / DomainReferenceData.PreciousMetals.MaximumFinenessPermille) *
+                    price;
                 holding.TotalValue = holding.CurrentValue * holding.Quantity;
             }
         }
@@ -262,8 +281,7 @@ namespace PreciousMetalsManager.ViewModels
             }
         }
 
-        // Hardcoded here for now, may be extended in the future to also use different currencies and units
-        private string _priceUnit = "€/g";
+        private string _priceUnit = DomainReferenceData.Currency.PricePerGramUnit;
         public string PriceUnit
         {
             get => _priceUnit;
@@ -282,22 +300,20 @@ namespace PreciousMetalsManager.ViewModels
             }
         }
 
-        public string CurrencyUnit => "(€)";
-        public string CurrencyUnitSimplyfied => "€";
-        public string WeightUnit => "(g)";
-        public string PurityUnit => "(‰)";
+        public string CurrencyUnit => DomainReferenceData.Currency.CurrencyUnit;
+        public string CurrencyUnitSimplyfied => DomainReferenceData.Currency.SimplifiedCurrencyUnit;
+        public string WeightUnit => DomainReferenceData.Currency.WeightUnit;
+        public string PurityUnit => DomainReferenceData.Currency.PurityUnit;
 
-        // Common purities for metals for easy selection in the UI, may be adjusted in the future
-        public ObservableCollection<string> CommonPurities { get; } = new()
-        {
-            "999.9", "925.0", "900.0", "835.0", "800.0", "750.0", "625.0"
-        };
+        public ObservableCollection<string> CommonPurities { get; } = new(
+            DomainReferenceData.PreciousMetals.CommonFinenessValues
+                .Select(value => value.ToString(PurityNumberFormat, CultureInfo.InvariantCulture)));
 
-        public string GoldPriceDisplay => $"{GoldPrice:F2}{PriceUnit}";
-        public string SilverPriceDisplay => $"{SilverPrice:F2}{PriceUnit}";
-        public string PlatinumPriceDisplay => $"{PlatinumPrice:F2}{PriceUnit}";
-        public string PalladiumPriceDisplay => $"{PalladiumPrice:F2}{PriceUnit}";
-        public string BroncePriceDisplay => $"{BroncePrice:F2}{PriceUnit}";
+        public string GoldPriceDisplay => $"{FormatPrice(GoldPrice)}{PriceUnit}";
+        public string SilverPriceDisplay => $"{FormatPrice(SilverPrice)}{PriceUnit}";
+        public string PlatinumPriceDisplay => $"{FormatPrice(PlatinumPrice)}{PriceUnit}";
+        public string PalladiumPriceDisplay => $"{FormatPrice(PalladiumPrice)}{PriceUnit}";
+        public string BroncePriceDisplay => $"{FormatPrice(BroncePrice)}{PriceUnit}";
 
         private decimal GetMarketPrice(MetalType type)
         {
@@ -449,13 +465,10 @@ namespace PreciousMetalsManager.ViewModels
                 return;
             }
 
-            // 1 troy ounce = 31.1g (may be adjusted to the exact value in the future)
-            const decimal gramsPerOunce = 31.1m;
-
-            var goldPrice = Math.Round(dto.GoldEur / gramsPerOunce, 2);
-            var silverPrice = Math.Round(dto.SilverEur / gramsPerOunce, 2);
-            var platinumPrice = Math.Round(dto.PlatinumEur / gramsPerOunce, 2);
-            var palladiumPrice = Math.Round(dto.PalladiumEur / gramsPerOunce, 2);
+            var goldPrice = ConvertOuncePriceToGramPrice(dto.GoldEur);
+            var silverPrice = ConvertOuncePriceToGramPrice(dto.SilverEur);
+            var platinumPrice = ConvertOuncePriceToGramPrice(dto.PlatinumEur);
+            var palladiumPrice = ConvertOuncePriceToGramPrice(dto.PalladiumEur);
 
             var hasChanges = false;
             hasChanges |= SetPriceCore(ref _goldPrice, goldPrice, nameof(GoldPrice), nameof(GoldPriceDisplay));
@@ -566,7 +579,7 @@ namespace PreciousMetalsManager.ViewModels
 
         private void ExportSimpleHoldings()
         {
-            var dateString = DateTime.Now.ToString("dd-MM-yyyy");
+            var dateString = DateTime.Now.ToString(ExportFileDateFormat, CultureInfo.InvariantCulture);
             var exportFileName = $"{L("ExportButton")}_{dateString}.csv";
 
             var saveFileDialog = new SaveFileDialog
@@ -599,7 +612,7 @@ namespace PreciousMetalsManager.ViewModels
 
         private void ExportDetailedHoldings()
         {
-            var dateString = DateTime.Now.ToString("dd-MM-yyyy");
+            var dateString = DateTime.Now.ToString(ExportFileDateFormat, CultureInfo.InvariantCulture);
             var detailedSuffix = L("ExportDialog_Detailed");
             var exportFileName = $"{L("ExportButton")}_{dateString}_{detailedSuffix}.csv";
 
@@ -635,11 +648,12 @@ namespace PreciousMetalsManager.ViewModels
         {
             try
             {
-                var dialog = new Microsoft.Win32.OpenFileDialog
+                var dialog = new OpenFileDialog
                 {
-                    Filter = "CSV-Dateien (*.csv)|*.csv",
+                    Filter = L("ImportDialog_Filter"),
                     Title = L("ImportDialog_Title")
                 };
+
                 if (dialog.ShowDialog() != true)
                     return;
 
@@ -648,10 +662,13 @@ namespace PreciousMetalsManager.ViewModels
                     throw new InvalidOperationException(L("ImportDialog_NoData"));
 
                 var newHoldings = new List<MetalHolding>();
-                int lineNumber = 1;
+                var lineNumber = 1;
+
                 foreach (var line in lines)
                 {
-                    if (string.IsNullOrWhiteSpace(line)) continue;
+                    if (string.IsNullOrWhiteSpace(line))
+                        continue;
+
                     var values = line.Split(';');
                     if (values.Length < 8)
                         throw new FormatException($"{L("ImportDialog_InvalidFormat")} (Line {lineNumber})");
@@ -667,14 +684,16 @@ namespace PreciousMetalsManager.ViewModels
                             Weight = decimal.Parse(values[4]),
                             Quantity = int.Parse(values[5]),
                             PurchasePrice = decimal.Parse(values[6]),
-                            PurchaseDate = DateTime.ParseExact(values[7], "yyyy-MM-dd", null)
+                            PurchaseDate = DateTime.ParseExact(values[7], ImportExportCsvDateFormat, CultureInfo.InvariantCulture)
                         };
+
                         newHoldings.Add(holding);
                     }
                     catch (Exception)
                     {
                         throw new FormatException($"{L("ImportDialog_InvalidFormat")} (Line {lineNumber})");
                     }
+
                     lineNumber++;
                 }
 

--- a/PreciousMetalsManager/Views/EditPricesDialog.xaml.cs
+++ b/PreciousMetalsManager/Views/EditPricesDialog.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
@@ -12,6 +11,10 @@ namespace PreciousMetalsManager.Views
     /// </summary>
     public partial class EditPricesDialog : Window
     {
+        private const string PriceNumberFormat = "F2";
+        private static readonly string DefaultPriceText = 0m.ToString(PriceNumberFormat, CultureInfo.InvariantCulture);
+        private static readonly Regex PriceInputRegex = new(@"^[0-9\.,]+$");
+
         public decimal GoldPrice { get; private set; }
         public decimal SilverPrice { get; private set; }
         public decimal PlatinumPrice { get; private set; }
@@ -19,29 +22,40 @@ namespace PreciousMetalsManager.Views
         public decimal BroncePrice { get; private set; }
         public string PriceUnit { get; }
 
-        private static readonly Regex PriceInputRegex = new(@"^[0-9\.,]+$");
-
         public EditPricesDialog(decimal gold, decimal silver, decimal platinum, decimal palladium, decimal bronce, string priceUnit)
         {
             InitializeComponent();
-            GoldPriceTextBox.Text = gold.ToString("F2", CultureInfo.InvariantCulture);
-            SilverPriceTextBox.Text = silver.ToString("F2", CultureInfo.InvariantCulture);
-            PlatinumPriceTextBox.Text = platinum.ToString("F2", CultureInfo.InvariantCulture);
-            PalladiumPriceTextBox.Text = palladium.ToString("F2", CultureInfo.InvariantCulture);
-            BroncePriceTextBox.Text = bronce.ToString("F2", CultureInfo.InvariantCulture);
+            GoldPriceTextBox.Text = FormatPrice(gold);
+            SilverPriceTextBox.Text = FormatPrice(silver);
+            PlatinumPriceTextBox.Text = FormatPrice(platinum);
+            PalladiumPriceTextBox.Text = FormatPrice(palladium);
+            BroncePriceTextBox.Text = FormatPrice(bronce);
             PriceUnit = priceUnit;
             DataContext = this;
         }
 
+        private static string NormalizeDecimalInput(string text)
+            => text.Replace(',', '.');
+
+        private static bool TryParseInvariantDecimal(string text, out decimal value)
+            => decimal.TryParse(
+                NormalizeDecimalInput(text),
+                NumberStyles.Any,
+                CultureInfo.InvariantCulture,
+                out value);
+
+        private static string FormatPrice(decimal value)
+            => value.ToString(PriceNumberFormat, CultureInfo.InvariantCulture);
+
         private static bool TryParseNonNegativePrice(string text, out decimal value)
-            => decimal.TryParse(text.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out value) && value >= 0;
+            => TryParseInvariantDecimal(text, out value) && value >= 0;
 
         private static string NormalizeNonNegativePrice(string text)
         {
             if (!TryParseNonNegativePrice(text, out var value))
-                return "0.00";
+                return DefaultPriceText;
 
-            return value.ToString("F2", CultureInfo.InvariantCulture);
+            return FormatPrice(value);
         }
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)
@@ -88,7 +102,6 @@ namespace PreciousMetalsManager.Views
 
         private void PriceTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
         {
-            // Allows only numbers, commas and dots to be entered
             e.Handled = !PriceInputRegex.IsMatch(e.Text);
         }
 

--- a/PreciousMetalsManager/Views/HoldingDialog.xaml
+++ b/PreciousMetalsManager/Views/HoldingDialog.xaml
@@ -48,7 +48,6 @@
             </Label>
             <ComboBox Name="PurityComboBox"
                       IsEditable="True"
-                      Text="999.9"
                       Width="130"
                       HorizontalAlignment="Center"
                       HorizontalContentAlignment="Center"
@@ -65,7 +64,6 @@
                 </StackPanel>
             </Label>
             <TextBox Name="WeightTextBox"
-                     Text="1.00"
                      Width="130"
                      HorizontalAlignment="Center"
                      HorizontalContentAlignment="Center"
@@ -76,7 +74,6 @@
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                 <Button Content="▲" Width="25" Click="IncreaseQuantity_Click"/>
                 <TextBox Name="QuantityTextBox"
-                         Text="1"
                          Width="80"
                          HorizontalContentAlignment="Center"
                          HorizontalAlignment="Center"
@@ -92,7 +89,6 @@
                 </StackPanel>
             </Label>
             <TextBox Name="PurchasePriceTextBox"
-                     Text="0.00"
                      Width="130"
                      HorizontalAlignment="Center"
                      HorizontalContentAlignment="Center"

--- a/PreciousMetalsManager/Views/HoldingDialog.xaml.cs
+++ b/PreciousMetalsManager/Views/HoldingDialog.xaml.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
+using PreciousMetalsManager.Domain;
 using PreciousMetalsManager.Models;
 
 namespace PreciousMetalsManager.Views
@@ -11,6 +14,20 @@ namespace PreciousMetalsManager.Views
     /// </summary>
     public partial class HoldingDialog : Window
     {
+        private const int MinimumQuantity = 1;
+        private const int MinimumPrice = 0;
+        private const decimal MinimumWeight = 0.01m;
+        private const decimal MinimumPurity = 0.1m;
+        private const int PurityDecimalPlaces = 1;
+        private const int WeightDecimalPlaces = 2;
+        private const string PurityNumberFormat = "F1";
+        private const string WeightNumberFormat = "F2";
+        private const string PriceNumberFormat = "F2";
+        private const decimal MinimumPositiveWeight = 0.01m;
+
+        private static readonly Regex IntegerInputRegex = new(@"^[0-9]+$");
+        private static readonly Regex DecimalInputRegex = new(@"^[0-9\.,]+$");
+
         public CollectableType SelectedCollectableType { get; set; } = CollectableType.Bullion;
 
         public MetalHolding? NewHolding { get; private set; }
@@ -20,6 +37,18 @@ namespace PreciousMetalsManager.Views
 
         private string _originalFormText = string.Empty;
 
+        private static string DefaultPurityText =>
+            DomainReferenceData.PreciousMetals.MaximumFinenessPermille.ToString(PurityNumberFormat, CultureInfo.InvariantCulture);
+
+        private static string DefaultWeightText =>
+            1m.ToString(WeightNumberFormat, CultureInfo.InvariantCulture);
+
+        private static string DefaultQuantityText =>
+            MinimumQuantity.ToString(CultureInfo.InvariantCulture);
+
+        private static string DefaultPurchasePriceText =>
+            0m.ToString(PriceNumberFormat, CultureInfo.InvariantCulture);
+
         public HoldingDialog()
         {
             InitializeComponent();
@@ -27,8 +56,32 @@ namespace PreciousMetalsManager.Views
             MetalTypeComboBox.SelectedIndex = 0;
             PurchaseDatePicker.SelectedDate = DateTime.Today;
 
+            PurityComboBox.Text = DefaultPurityText;
+            WeightTextBox.Text = DefaultWeightText;
+            QuantityTextBox.Text = DefaultQuantityText;
+            PurchasePriceTextBox.Text = DefaultPurchasePriceText;
+
             Loaded += HoldingDialog_Loaded;
         }
+
+        private static string NormalizeDecimalInput(string text)
+            => text.Replace(',', '.');
+
+        private static bool TryParseInvariantDecimal(string text, out decimal value)
+            => decimal.TryParse(
+                NormalizeDecimalInput(text),
+                NumberStyles.Any,
+                CultureInfo.InvariantCulture,
+                out value);
+
+        private static string FormatPurity(decimal value)
+            => value.ToString(PurityNumberFormat, CultureInfo.InvariantCulture);
+
+        private static string FormatWeight(decimal value)
+            => value.ToString(WeightNumberFormat, CultureInfo.InvariantCulture);
+
+        private static string FormatPrice(decimal value)
+            => value.ToString(PriceNumberFormat, CultureInfo.InvariantCulture);
 
         private void HoldingDialog_Loaded(object sender, RoutedEventArgs e)
         {
@@ -40,7 +93,6 @@ namespace PreciousMetalsManager.Views
 
         private bool TryCreateHolding()
         {
-            // Goes sure no field is empty or unvalid
             if (MetalTypeComboBox.SelectedItem == null)
             {
                 MetalTypeComboBox.Focus();
@@ -58,25 +110,25 @@ namespace PreciousMetalsManager.Views
             FormTextBox.ClearValue(BorderBrushProperty);
             FormTextBox.ClearValue(BorderThicknessProperty);
 
-            if (!decimal.TryParse(PurityComboBox.Text.Replace(',', '.'), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var purity) || purity <= 0)
+            if (!TryParseInvariantDecimal(PurityComboBox.Text, out var purity) || purity < MinimumPurity)
             {
                 PurityComboBox.Focus();
                 return false;
             }
 
-            if (!decimal.TryParse(WeightTextBox.Text.Replace(',', '.'), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var weight) || weight <= 0)
+            if (!TryParseInvariantDecimal(WeightTextBox.Text, out var weight) || weight < MinimumWeight)
             {
                 WeightTextBox.Focus();
                 return false;
             }
 
-            if (!int.TryParse(QuantityTextBox.Text, out var quantity) || quantity <= 0)
+            if (!int.TryParse(QuantityTextBox.Text, out var quantity) || quantity < MinimumQuantity)
             {
                 QuantityTextBox.Focus();
                 return false;
             }
 
-            if (!decimal.TryParse(PurchasePriceTextBox.Text.Replace(',', '.'), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var price) || price < 0)
+            if (!TryParseInvariantDecimal(PurchasePriceTextBox.Text, out var price) || price < MinimumPrice)
             {
                 PurchasePriceTextBox.Focus();
                 return false;
@@ -88,7 +140,6 @@ namespace PreciousMetalsManager.Views
                 return false;
             }
 
-            // Saves new values
             NewHolding = new MetalHolding
             {
                 MetalType = (MetalType)MetalTypeComboBox.SelectedItem,
@@ -99,8 +150,6 @@ namespace PreciousMetalsManager.Views
                 PurchasePrice = price,
                 PurchaseDate = PurchaseDatePicker.SelectedDate.Value,
                 CollectableType = SelectedCollectableType,
-                CurrentValue = 0,
-                TotalValue = 0
             };
 
             return true;
@@ -135,40 +184,38 @@ namespace PreciousMetalsManager.Views
 
         private void IncreaseQuantity_Click(object sender, RoutedEventArgs e)
         {
-            if (int.TryParse(QuantityTextBox.Text, out int value))
+            if (int.TryParse(QuantityTextBox.Text, out var value))
             {
-                QuantityTextBox.Text = (value + 1).ToString();
+                QuantityTextBox.Text = (value + 1).ToString(CultureInfo.InvariantCulture);
             }
             else
             {
-                QuantityTextBox.Text = "1";
+                QuantityTextBox.Text = DefaultQuantityText;
             }
         }
 
         private void DecreaseQuantity_Click(object sender, RoutedEventArgs e)
         {
-            if (int.TryParse(QuantityTextBox.Text, out int value) && value > 1)
+            if (int.TryParse(QuantityTextBox.Text, out var value) && value > MinimumQuantity)
             {
-                QuantityTextBox.Text = (value - 1).ToString();
+                QuantityTextBox.Text = (value - 1).ToString(CultureInfo.InvariantCulture);
             }
             else
             {
-                QuantityTextBox.Text = "1";
+                QuantityTextBox.Text = DefaultQuantityText;
             }
         }
 
         private void QuantityTextBox_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
         {
-            // Allows only numbers to be entered
-            e.Handled = !System.Text.RegularExpressions.Regex.IsMatch(e.Text, @"^[0-9]+$");
+            e.Handled = !IntegerInputRegex.IsMatch(e.Text);
         }
 
         private void QuantityTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            // Corrects invalid values to 1
-            if (!int.TryParse(QuantityTextBox.Text, out int value) || value < 1)
+            if (!int.TryParse(QuantityTextBox.Text, out var value) || value < MinimumQuantity)
             {
-                QuantityTextBox.Text = "1";
+                QuantityTextBox.Text = DefaultQuantityText;
             }
         }
 
@@ -188,78 +235,65 @@ namespace PreciousMetalsManager.Views
 
         private void PurityComboBox_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
         {
-            // Allows only numbers, commas and dots to be entered
-            e.Handled = !System.Text.RegularExpressions.Regex.IsMatch(e.Text, @"^[0-9\.,]+$");
+            e.Handled = !DecimalInputRegex.IsMatch(e.Text);
         }
 
         private void PurityComboBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            var text = PurityComboBox.Text.Replace(',', '.');
-            if (!decimal.TryParse(text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var value))
+            if (!TryParseInvariantDecimal(PurityComboBox.Text, out var value))
             {
-                // Corrects invalid values to 999,9
-                PurityComboBox.Text = "999.9";
+                PurityComboBox.Text = DefaultPurityText;
                 return;
             }
 
-            // Rounds the value to 1 decimal place
-            var rounded = Math.Round(value, 1, MidpointRounding.AwayFromZero);
+            var rounded = Math.Round(value, PurityDecimalPlaces, MidpointRounding.AwayFromZero);
 
-            if (rounded > 999.9m)
-                rounded = 999.9m;
-            else if (rounded < 0.1m)
-                rounded = 0.1m;
+            if (rounded > DomainReferenceData.PreciousMetals.MaximumFinenessPermille)
+                rounded = DomainReferenceData.PreciousMetals.MaximumFinenessPermille;
+            else if (rounded < DomainReferenceData.PreciousMetals.MinimumFinenessPermille)
+                rounded = DomainReferenceData.PreciousMetals.MinimumFinenessPermille;
 
-            PurityComboBox.Text = rounded.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+            PurityComboBox.Text = FormatPurity(rounded);
         }
 
         private void PurchasePriceTextBox_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
         {
-            // Allows only numbers, commas and dots to be entered
-            e.Handled = !System.Text.RegularExpressions.Regex.IsMatch(e.Text, @"^[0-9\.,]+$");
+            e.Handled = !DecimalInputRegex.IsMatch(e.Text);
         }
 
         private void PurchasePriceTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            var text = PurchasePriceTextBox.Text.Replace(',', '.');
-            if (!decimal.TryParse(text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var value) || value < 0)
+            if (!TryParseInvariantDecimal(PurchasePriceTextBox.Text, out var value) || value < 0)
             {
-                // Corrects invalid values to 0.00
-                PurchasePriceTextBox.Text = "0.00";
+                PurchasePriceTextBox.Text = DefaultPurchasePriceText;
             }
             else
             {
-                // Formats the value to 2 decimal places
-                PurchasePriceTextBox.Text = value.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
+                PurchasePriceTextBox.Text = FormatPrice(value);
             }
         }
 
         private void WeightTextBox_PreviewTextInput(object sender, System.Windows.Input.TextCompositionEventArgs e)
         {
-            // Allows only numbers, commas and dots to be entered
-            e.Handled = !System.Text.RegularExpressions.Regex.IsMatch(e.Text, @"^[0-9\.,]+$");
+            e.Handled = !DecimalInputRegex.IsMatch(e.Text);
         }
 
         private void WeightTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            var text = WeightTextBox.Text.Replace(',', '.');
-
-            // Corrects invalid values
-            if (!decimal.TryParse(text, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var value) || value <= 0)
+            if (!TryParseInvariantDecimal(WeightTextBox.Text, out var value) || value <= 0)
             {
-                WeightTextBox.Text = "1.00";
+                WeightTextBox.Text = DefaultWeightText;
                 return;
             }
 
-            var formatted = value.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
-
-            if (formatted == "0.00")
+            var rounded = Math.Round(value, WeightDecimalPlaces, MidpointRounding.AwayFromZero);
+            if (rounded < MinimumPositiveWeight)
             {
-                WeightTextBox.Text = "0.01";
+                WeightTextBox.Text = FormatWeight(MinimumPositiveWeight);
                 return;
             }
 
-            WeightTextBox.Text = formatted;
+            WeightTextBox.Text = FormatWeight(rounded);
         }
 
         private void PurchaseDatePicker_LostFocus(object sender, RoutedEventArgs e)


### PR DESCRIPTION
# Summary
Centralize fixed reference data and replace domain-related magic numbers with named constants or shared reference values.

# Changelog
• Added DomainReferenceData as the central place for fixed shared domain values.
• Centralized supported currency metadata and shared unit strings.
• Centralized precious metal fineness reference values and common UI purity options.
• Centralized shared tax and precious metal domain values..
• Updated localization file.

# Testing
No issues found.