### PR TITLE
TASK-12: Replace remaining MainWindow event handlers with MVVM-friendly behaviors

### DIFF
--- a/PreciousMetalsManager/Behaviors/ButtonContextMenuBehavior.cs
+++ b/PreciousMetalsManager/Behaviors/ButtonContextMenuBehavior.cs
@@ -1,0 +1,42 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PreciousMetalsManager.Behaviors
+{
+    public static class ButtonContextMenuBehavior
+    {
+        public static readonly DependencyProperty OpenOnClickProperty =
+            DependencyProperty.RegisterAttached(
+                "OpenOnClick",
+                typeof(bool),
+                typeof(ButtonContextMenuBehavior),
+                new PropertyMetadata(false, OnOpenOnClickChanged));
+
+        public static void SetOpenOnClick(DependencyObject element, bool value)
+            => element.SetValue(OpenOnClickProperty, value);
+
+        public static bool GetOpenOnClick(DependencyObject element)
+            => (bool)element.GetValue(OpenOnClickProperty);
+
+        private static void OnOpenOnClickChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not Button button)
+                return;
+
+            button.Click -= Button_Click;
+
+            if (e.NewValue is true)
+                button.Click += Button_Click;
+        }
+
+        private static void Button_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button button || button.ContextMenu == null)
+                return;
+
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.IsOpen = true;
+            e.Handled = true;
+        }
+    }
+}

--- a/PreciousMetalsManager/Behaviors/DataGridSelectionBehavior.cs
+++ b/PreciousMetalsManager/Behaviors/DataGridSelectionBehavior.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace PreciousMetalsManager.Behaviors
+{
+    public static class DataGridSelectionBehavior
+    {
+        public static readonly DependencyProperty SelectionChangedCommandProperty =
+            DependencyProperty.RegisterAttached(
+                "SelectionChangedCommand",
+                typeof(ICommand),
+                typeof(DataGridSelectionBehavior),
+                new PropertyMetadata(null, OnSelectionChangedCommandChanged));
+
+        public static void SetSelectionChangedCommand(DependencyObject element, ICommand? value)
+            => element.SetValue(SelectionChangedCommandProperty, value);
+
+        public static ICommand? GetSelectionChangedCommand(DependencyObject element)
+            => (ICommand?)element.GetValue(SelectionChangedCommandProperty);
+
+        private static void OnSelectionChangedCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not DataGrid dataGrid)
+                return;
+
+            dataGrid.SelectionChanged -= DataGrid_SelectionChanged;
+
+            if (e.NewValue is ICommand)
+                dataGrid.SelectionChanged += DataGrid_SelectionChanged;
+        }
+
+        private static void DataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender is not DataGrid dataGrid)
+                return;
+
+            var command = GetSelectionChangedCommand(dataGrid);
+            if (command == null)
+                return;
+
+            var selection = dataGrid.SelectedItems.Cast<object>().ToList();
+
+            if (command.CanExecute(selection))
+                command.Execute(selection);
+        }
+    }
+}

--- a/PreciousMetalsManager/MainWindow.xaml
+++ b/PreciousMetalsManager/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:models="clr-namespace:PreciousMetalsManager.Models"
+        xmlns:behaviors="clr-namespace:PreciousMetalsManager.Behaviors"
         mc:Ignorable="d"
         Title="{DynamicResource MainWindow_Title}" Height="450" Width="1000">
 
@@ -59,7 +60,10 @@
 
             <Border Padding="4" Background="#FFF8F8F8" CornerRadius="4">
                 <StackPanel Orientation="Horizontal">
-                    <Button Content="{DynamicResource ExportButton}" Width="80" Margin="0,0,5,0" Click="ExportButton_Click">
+                    <Button Content="{DynamicResource ExportButton}"
+                            Width="80"
+                            Margin="0,0,5,0"
+                            behaviors:ButtonContextMenuBehavior.OpenOnClick="True">
                         <Button.ContextMenu>
                             <ContextMenu>
                                 <MenuItem Header="{DynamicResource ExportDialog_Simple}" Command="{Binding ExportSimpleCommand}" />
@@ -140,7 +144,7 @@
             <DataGrid x:Name="MainDataGrid"
                       ItemsSource="{Binding FilteredHoldings}"
                       SelectedItem="{Binding SelectedHolding, Mode=TwoWay}"
-                      SelectionChanged="MainDataGrid_SelectionChanged"
+                      behaviors:DataGridSelectionBehavior.SelectionChangedCommand="{Binding UpdateSelectionCommand}"
                       AutoGenerateColumns="False"
                       CanUserAddRows="False"
                       IsReadOnly="True"

--- a/PreciousMetalsManager/MainWindow.xaml.cs
+++ b/PreciousMetalsManager/MainWindow.xaml.cs
@@ -75,24 +75,6 @@ namespace PreciousMetalsManager
             DispatcherPriority.Background);
         }
 
-        private void ExportButton_Click(object sender, RoutedEventArgs e)
-        {
-            var button = sender as Button;
-            if (button?.ContextMenu != null)
-            {
-                button.ContextMenu.PlacementTarget = button;
-                button.ContextMenu.IsOpen = true;
-            }
-        }
-
-        private void MainDataGrid_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (DataContext is not ViewModel vm)
-                return;
-
-            vm.UpdateSelection(MainDataGrid.SelectedItems.OfType<Models.MetalHolding>());
-        }
-
         private void ViewModel_LanguageLayoutRefreshRequested(object? sender, EventArgs e)
         {
             MetalTypeFilterComboBox.Items.Refresh();

--- a/PreciousMetalsManager/ViewModel/ViewModel.cs
+++ b/PreciousMetalsManager/ViewModel/ViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.ObjectModel;
 using PreciousMetalsManager.Models;
 using System.ComponentModel;
@@ -180,6 +181,18 @@ namespace PreciousMetalsManager.ViewModels
                 ToggleLanguage();
                 LanguageLayoutRefreshRequested?.Invoke(this, EventArgs.Empty);
             });
+            UpdateSelectionCommand = new RelayCommand(ExecuteUpdateSelection);
+        }
+
+        private void ExecuteUpdateSelection(object? parameter)
+        {
+            if (parameter is IEnumerable items)
+            {
+                UpdateSelection(items.OfType<MetalHolding>());
+                return;
+            }
+
+            UpdateSelection(Array.Empty<MetalHolding>());
         }
 
         private void Holdings_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -769,6 +782,7 @@ namespace PreciousMetalsManager.ViewModels
         public ICommand DeleteSelectedHoldingsCommand { get; }
         public ICommand EditPricesCommand { get; }
         public ICommand ToggleLanguageCommand { get; }
+        public ICommand UpdateSelectionCommand { get; }
 
         public event PropertyChangedEventHandler? PropertyChanged;
 


### PR DESCRIPTION
# Summary
Replace remaining main window code-behind interactions with command-based MVVM actions.

# Changelog
• Replaced the remaining main window interaction handlers with command-driven or view-attached behavior based interactions.
• Removed code-behind handling for main window selection updates.
• Removed code-behind handling for export context menu opening.
• Kept the main workflow inside the main `ViewModel`.
• Left only minimal view-specific behavior in `MainWindow.xaml.cs`.

# Testing
No issues found.

# Notes
Purely view-specific behavior that is not reasonable to move into the main `ViewModel` was intentionally kept in the view layer.