### PR TITLE
TASK-13: Move EditPricesDialog ViewModel creation out of code-behind

### DIFF
--- a/PreciousMetalsManager/Services/EditPricesDialogService.cs
+++ b/PreciousMetalsManager/Services/EditPricesDialogService.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Windows;
+using PreciousMetalsManager.ViewModels;
 using PreciousMetalsManager.Views;
 
 namespace PreciousMetalsManager.Services
@@ -14,13 +15,15 @@ namespace PreciousMetalsManager.Services
             decimal broncePrice,
             string priceUnit)
         {
-            var dialog = new EditPricesDialog(
+            var dialogViewModel = new EditPricesDialogViewModel(
                 goldPrice,
                 silverPrice,
                 platinumPrice,
                 palladiumPrice,
                 broncePrice,
-                priceUnit)
+                priceUnit);
+
+            var dialog = new EditPricesDialog(dialogViewModel)
             {
                 Owner = GetOwnerWindow()
             };
@@ -28,13 +31,12 @@ namespace PreciousMetalsManager.Services
             if (dialog.ShowDialog() != true)
                 return null;
 
-            var vm = dialog.ViewModel;
             return new PriceEditResult(
-                vm.GoldPrice,
-                vm.SilverPrice,
-                vm.PlatinumPrice,
-                vm.PalladiumPrice,
-                vm.BroncePrice);
+                dialogViewModel.GoldPrice,
+                dialogViewModel.SilverPrice,
+                dialogViewModel.PlatinumPrice,
+                dialogViewModel.PalladiumPrice,
+                dialogViewModel.BroncePrice);
         }
 
         private static Window? GetOwnerWindow()

--- a/PreciousMetalsManager/Views/EditPricesDialog.xaml.cs
+++ b/PreciousMetalsManager/Views/EditPricesDialog.xaml.cs
@@ -9,18 +9,17 @@ namespace PreciousMetalsManager.Views
     {
         private static readonly Regex PriceInputRegex = new(@"^[0-9\.,]+$");
 
-        public EditPricesDialog(decimal gold, decimal silver, decimal platinum, decimal palladium, decimal bronce, string priceUnit)
+        public EditPricesDialog(EditPricesDialogViewModel viewModel)
         {
             InitializeComponent();
 
-            var viewModel = new EditPricesDialogViewModel(gold, silver, platinum, palladium, bronce, priceUnit);
+            DataContext = viewModel;
+
             viewModel.RequestCloseRequested += (_, accepted) =>
             {
                 DialogResult = accepted;
                 Close();
             };
-
-            DataContext = viewModel;
         }
 
         public EditPricesDialogViewModel ViewModel => (EditPricesDialogViewModel)DataContext;


### PR DESCRIPTION
Summary
Move dialog workflow and dialog state handling into dedicated dialog view models.

Changelog
• Added dedicated view models for `HoldingDialog` and `EditPricesDialog`.
• Moved dialog state into bindable properties instead of reading values directly from controls in code-behind.
• Moved dialog save/cancel workflow handling behind commands and dialog view model events.
• Moved `EditPricesDialogViewModel` creation out of code-behind into the dialog service.
• Kept dialog services responsible for dialog coordination and result mapping.

Testing
No issues found.